### PR TITLE
Listen for wheel event instead of mousewheel event.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ fixes https://github.com/comfyanonymous/ComfyUI/issues/2059
 
 ### Installation
 
-1. Put this folder into ComfyUI/custom_nodes/TinkerBot-tech-for-ComfyUI-Touchpad
+1. Put this folder into ComfyUI/web/extensions/TinkerBot-tech-for-ComfyUI-Touchpad
 2. Restart ComfyUI
 3. Reload the UI
 4. Enjoy!

--- a/web/fix touchpad pan and zoom.js
+++ b/web/fix touchpad pan and zoom.js
@@ -1,21 +1,17 @@
-// @ts-check
-/** @type {any} */
-const { self } = window
+import { app } from "../../../scripts/app.js";
 
-/** @type {import("../../../web/types/litegraph")} */
-const { LGraphCanvas } = self
-
-// @ts-ignore
-import * as ComfyUI_module from "../../../scripts/app.js"
-/** @type { import("../../../web/scripts/app.js") } */
-const { app } = ComfyUI_module
-
-//////////////////////////////
+app.registerExtension({
+  name: "ComfyUI-Mac-Trackpad",
+  async setup(app) {
+    app.canvas.canvas.removeEventListener("mousewheel");
+    app.canvas.canvas.addEventListener("wheel", processWheel.bind(app.canvas), false);
+  }
+});
 
 /**
  * Smooth scrolling for touchpad
  */
-LGraphCanvas.prototype.processMouseWheel = function (/** @type {WheelEvent}*/ event) {
+function processWheel(/** @type {WheelEvent}*/ event) {
   if (!this.graph || !this.allow_dragcanvas) return
 
   const { clientX: x, clientY: y } = event


### PR DESCRIPTION
Fixes subtleGradient/TinkerBot-tech-for-ComfyUI-Touchpad/#7.

The breakage is present in (at least) Firefox, and is a side-effect of ComfyUI's LGraphCanvas listening for the deprecated `mousewheel` event instead of the modern `wheel` event, which passes insufficient information to the event handler.

In order to manipulate event listeners, we need to be able to run code after application setup is complete. To facilitate that, the code has been reworked as an extension instead of a custom node.